### PR TITLE
Fix repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/backlog.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com:nulab/backlog-js.git"
+    "url": "git://github.com/nulab/backlog-js.git"
   },
   "scripts": {
     "test": "mocha --timeout 10000 --compilers ts:espower-typescript/guess test/test*.ts",


### PR DESCRIPTION
This seems to be a broken link from https://www.npmjs.com/package/backlog-js and fails the parser in https://www.npmjs.com/package/github-url-to-object