### PR TITLE
Remove es6-promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ Append your "API Key" or "OAuth2 Access Token" to requests to the API to return 
 ``` javascript
 import 'isomorphic-form-data';
 import 'isomorphic-fetch';
-import * as es6promise from 'es6-promise';
 import * as backlogjs from 'backlog-js';
-
-es6promise.polyfill();
 
 // 'xxx.backlog.jp' or 'xxx.backlogtool.com' or 'your package host'
 const host = 'yourSpaceHost';

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "browserify": "^17.0.0",
         "coveralls": "^3.1.1",
         "dotenv": "^16.0.0",
-        "es6-promise": "^4.2.8",
         "espower-typescript": "^10.0.0",
         "isomorphic-fetch": "^3.0.0",
         "isomorphic-form-data": "^2.0.0",
@@ -1400,12 +1399,6 @@
         "es6-symbol": "~3.1.1",
         "event-emitter": "~0.3.5"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "node_modules/es6-set": {
       "version": "0.1.5",
@@ -5770,12 +5763,6 @@
         "es6-symbol": "~3.1.1",
         "event-emitter": "~0.3.5"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
     },
     "es6-set": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "browserify": "^17.0.0",
     "coveralls": "^3.1.1",
     "dotenv": "^16.0.0",
-    "es6-promise": "^4.2.8",
     "espower-typescript": "^10.0.0",
     "isomorphic-fetch": "^3.0.0",
     "isomorphic-form-data": "^2.0.0",

--- a/test/test.ts
+++ b/test/test.ts
@@ -9,7 +9,6 @@ import * as Fixtures from './fixtures/index';
 import 'isomorphic-form-data';
 import 'isomorphic-fetch';
 
-require('es6-promise').polyfill();
 dotenv.config();
 
 const host = process.env.BACKLOG_HOST || 'example.backlog.jp';


### PR DESCRIPTION
Resolves #60 

Since `es6-promise` was in a devDependencies, we don't need to make a new release for this change.