### PR TITLE
Handle 204 No Content responses safely in parseJSON

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -77,6 +77,10 @@ export default class Request {
   }
 
   public parseJSON<T>(response: Response): Promise<T> {
+    if (response.status === 204 || response.headers.get("Content-Length") === "0") {
+      return Promise.resolve(undefined as unknown as T);
+    }
+
     return response.json();
   }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -202,5 +202,24 @@ describe("Backlog API", () => {
       throw err;
     });
   });
-
+  it('should mark notification as read (204 No Content)', done => {
+    const notificationId = 1234;
+  
+    mockRequest({
+      method: "POST",
+      path: `/api/v2/notifications/${notificationId}/markAsRead`,
+      query: { apiKey },
+      status: 204, // No Content
+      data: [],
+      times: 1,
+    });
+  
+    backlog.markAsReadNotification(notificationId).then(data => {
+      // Should resolve without error and without any value
+      assert(data === undefined); 
+      done();
+    }).catch(err => {
+      throw err;
+    });
+  });
 });


### PR DESCRIPTION
# Summary

This pull request improves the robustness of the parseJSON method by gracefully handling HTTP 204 No Content responses, which previously caused runtime errors due to .json() being called on an empty body.

# Context

Some Backlog API endpoints (e.g., POST /notifications/{id}/markAsRead) return a 204 No Content status without a response body. Calling response.json() in such cases throws a parsing error. This fix ensures the client behaves safely and predictably in those scenarios.

