### PR TITLE
fix: Remove isomorphic-fetch and isomorphic-form-data polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ $ npm install --save backlog-js
 Append your "API Key" or "OAuth2 Access Token" to requests to the API to return data.
 
 ``` javascript
-import 'isomorphic-form-data';
-import 'isomorphic-fetch';
 import * as backlogjs from 'backlog-js';
 
 // 'xxx.backlog.jp' or 'xxx.backlogtool.com' or 'your package host'

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,9 @@
       "devDependencies": {
         "@types/dotenv": "^6.1.1",
         "@types/empower": "^1.2.35",
-        "@types/isomorphic-fetch": "0.0.39",
         "@types/mocha": "^10.0.7",
         "@types/nock": "^10.0.3",
-        "@types/node": "^18",
+        "@types/node": ">=18",
         "@types/power-assert": "^1.5.12",
         "@types/power-assert-formatter": "^1.4.33",
         "@types/qs": "^6.9.15",
@@ -25,8 +24,6 @@
         "coveralls": "^3.1.1",
         "dotenv": "^16.4.5",
         "espower-typescript": "^10.0.1",
-        "isomorphic-fetch": "^3.0.0",
-        "isomorphic-form-data": "^2.0.0",
         "istanbul": "^0.4.5",
         "mocha": "^10.5.2",
         "nock": "^13.5.4",
@@ -34,6 +31,9 @@
         "typescript": "^5.5.2",
         "uglify-js": "^3.18.0",
         "undici": "^6.19.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -120,12 +120,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/empower-core/-/empower-core-1.2.0.tgz",
       "integrity": "sha512-aWPZHawyqm5EJ9jVIExsV0dWxzGp2bzSdfx0XvP/s5t9X/xAvnAWLhB9rB0kThuazR2WuY16VVtYT52hNGLucg==",
-      "dev": true
-    },
-    "node_modules/@types/isomorphic-fetch": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.39.tgz",
-      "integrity": "sha512-I0gou/ZdA1vMG7t7gMzL7VYu2xAKU78rW9U1l10MI0nn77pEHq3tQqHQ8hMmXdMpBlkxZOorjI4sO594Z3kKJw==",
       "dev": true
     },
     "node_modules/@types/mocha": {
@@ -2530,25 +2524,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "node_modules/isomorphic-form-data": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz",
-      "integrity": "sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==",
-      "dev": true,
-      "dependencies": {
-        "form-data": "^2.3.2"
-      }
-    },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -3141,26 +3116,6 @@
       },
       "engines": {
         "node": ">= 10.13"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/nopt": {
@@ -4252,12 +4207,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
-    },
     "node_modules/traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -4576,28 +4525,6 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-      "dev": true
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -4900,12 +4827,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/empower-core/-/empower-core-1.2.0.tgz",
       "integrity": "sha512-aWPZHawyqm5EJ9jVIExsV0dWxzGp2bzSdfx0XvP/s5t9X/xAvnAWLhB9rB0kThuazR2WuY16VVtYT52hNGLucg==",
-      "dev": true
-    },
-    "@types/isomorphic-fetch": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.39.tgz",
-      "integrity": "sha512-I0gou/ZdA1vMG7t7gMzL7VYu2xAKU78rW9U1l10MI0nn77pEHq3tQqHQ8hMmXdMpBlkxZOorjI4sO594Z3kKJw==",
       "dev": true
     },
     "@types/mocha": {
@@ -6844,25 +6765,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "isomorphic-form-data": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz",
-      "integrity": "sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==",
-      "dev": true,
-      "requires": {
-        "form-data": "^2.3.2"
-      }
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -7333,15 +7235,6 @@
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
-      }
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
       }
     },
     "nopt": {
@@ -8237,12 +8130,6 @@
         }
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
-    },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -8489,28 +8376,6 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-      "dev": true
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dev": true,
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@types/dotenv": "^6.1.1",
     "@types/empower": "^1.2.35",
-    "@types/isomorphic-fetch": "0.0.39",
     "@types/mocha": "^10.0.7",
     "@types/nock": "^10.0.3",
     "@types/node": "^18",
@@ -39,8 +38,6 @@
     "coveralls": "^3.1.1",
     "dotenv": "^16.4.5",
     "espower-typescript": "^10.0.1",
-    "isomorphic-fetch": "^3.0.0",
-    "isomorphic-form-data": "^2.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^10.5.2",
     "nock": "^13.5.4",
@@ -48,6 +45,9 @@
     "typescript": "^5.5.2",
     "uglify-js": "^3.18.0",
     "undici": "^6.19.2"
+  },
+  "engines": {
+    "node": ">= 18"
   },
   "keywords": [
     "nulab",

--- a/test/test.ts
+++ b/test/test.ts
@@ -3,8 +3,6 @@ import * as dotenv from 'dotenv';
 import * as backlogjs from '../src/index';
 import * as Fixtures from './fixtures/index';
 import { mockRequest, mockPrepare, mockCleanup } from './mock';
-import 'isomorphic-form-data';
-import 'isomorphic-fetch';
 import { before, after } from 'mocha';
 
 dotenv.config();


### PR DESCRIPTION
## Summary
- Removed `isomorphic-fetch` and `isomorphic-form-data` polyfills, as `fetch` and `FormData` are available as built-in global APIs in Node.js v18 and later.
- Added `engines.node: ">= 18"` to `package.json` to specify the minimum required Node.js version.
- Removed descriptions of unnecessary polyfills from the README and test code.

## Note
This change does not affect the runtime source code. Additionally, adding the engines field only triggers a warning and does not block user operations. Therefore, this change does not qualify as a breaking change.

## References
- Closes #2
- Closes #87