### PR TITLE
Remove nock in favor of undici MockAgent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,10 @@
         "qs": "^6.12.1"
       },
       "devDependencies": {
-        "@types/nock": "^10.0.3",
         "@types/node": "^25.2.3",
         "@types/qs": "^6.9.15",
         "coveralls": "^3.1.1",
         "dotenv": "^16.4.5",
-        "nock": "^13.5.4",
         "tsdown": "^0.21.1",
         "typescript": "^5.5.2",
         "undici": "^6.19.2",
@@ -531,15 +529,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/nock": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-10.0.3.tgz",
-      "integrity": "sha512-OthuN+2FuzfZO3yONJ/QVjKmLEuRagS9TV9lEId+WHL9KhftYG+/2z+pxlr0UgVVXSpVD8woie/3fzQn8ft/Ow==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "25.6.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
@@ -899,24 +888,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/defu": {
@@ -1711,12 +1682,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -1734,20 +1699,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/nock": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "propagate": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13"
       }
     },
     "node_modules/oauth-sign": {
@@ -1828,15 +1779,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/psl": {

--- a/package.json
+++ b/package.json
@@ -41,12 +41,10 @@
     "qs": "^6.12.1"
   },
   "devDependencies": {
-    "@types/nock": "^10.0.3",
     "@types/node": "^25.2.3",
     "@types/qs": "^6.9.15",
     "coveralls": "^3.1.1",
     "dotenv": "^16.4.5",
-    "nock": "^13.5.4",
     "tsdown": "^0.21.1",
     "typescript": "^5.5.2",
     "undici": "^6.19.2",

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,15 +1,15 @@
 import * as qs from "qs";
-import { setGlobalDispatcher, MockAgent, Interceptable } from "undici";
+import { setGlobalDispatcher, getGlobalDispatcher, MockAgent, Interceptable, Dispatcher } from "undici";
 
 let undiciInterceptable: Interceptable;
-
-type BodyMatcher = (body: string | Record<string, any>) => boolean;
+let mockAgent: MockAgent;
+let previousDispatcher: Dispatcher;
 
 interface MockParams {
   method: "GET" | "POST" | "DELETE";
   path: string;
   query?: Record<string, any>;
-  body?: BodyMatcher;
+  body?: string;
   status: number;
   data: any;
   headers?: Record<string, any>;
@@ -17,14 +17,15 @@ interface MockParams {
 }
 
 export const mockRequest = ({
-  path, method, query, status, data, headers, times
+  path, method, query, body, status, data, headers, times
 }: MockParams) => {
   const queryStr = qs.stringify(query, { arrayFormat: 'brackets' });
-  const newPath = `${path}?${queryStr}`
+  const newPath = queryStr ? `${path}?${queryStr}` : path;
 
   const interceptor = undiciInterceptable.intercept({
     method,
     path: newPath,
+    ...(body !== undefined && { body }),
   });
 
   interceptor
@@ -33,11 +34,14 @@ export const mockRequest = ({
 };
 
 export const mockPrepare = (host: string) => {
-  const mockAgent = new MockAgent();
+  previousDispatcher = getGlobalDispatcher();
+  mockAgent = new MockAgent();
   setGlobalDispatcher(mockAgent);
   undiciInterceptable = mockAgent.get(host);
 };
 
 export const mockCleanup = () => {
   undiciInterceptable.close();
+  mockAgent.close();
+  setGlobalDispatcher(previousDispatcher);
 };

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,10 +1,6 @@
 import * as qs from "qs";
-import nock from "nock";
 import { setGlobalDispatcher, MockAgent, Interceptable } from "undici";
 
-const nodeVersion = Number(process.versions.node.split(".")[0]);
-const isNativeFetch = nodeVersion >= 18;
-let nockScope: nock.Scope;
 let undiciInterceptable: Interceptable;
 
 type BodyMatcher = (body: string | Record<string, any>) => boolean;
@@ -21,51 +17,27 @@ interface MockParams {
 }
 
 export const mockRequest = ({
-  path, method, query, body, status, data, headers, times
+  path, method, query, status, data, headers, times
 }: MockParams) => {
   const queryStr = qs.stringify(query, { arrayFormat: 'brackets' });
   const newPath = `${path}?${queryStr}`
 
-  if (isNativeFetch) {
-    const interceptor = undiciInterceptable.intercept({
-      method,
-      path: newPath,
-    });
+  const interceptor = undiciInterceptable.intercept({
+    method,
+    path: newPath,
+  });
 
-    interceptor
-      .reply(status, data, { headers })
-      .times(times);
-  } else {
-    let interceptor: nock.Interceptor;
-
-    if (method === "GET") {
-      interceptor = nockScope.get(newPath);
-    } else if (method === "POST" ) {
-      interceptor = nockScope.post(newPath, body);
-    } else if (method === "DELETE") {
-      interceptor = nockScope.delete(newPath);
-    }
-
-    interceptor
-      .times(times)
-      .reply(status, data, headers);
-  }
+  interceptor
+    .reply(status, data, { headers })
+    .times(times);
 };
 
 export const mockPrepare = (host: string) => {
-  if (isNativeFetch) {
-    const mockAgent = new MockAgent();
-    setGlobalDispatcher(mockAgent);
-    undiciInterceptable = mockAgent.get(host);
-  } else {
-    nockScope = nock(host);
-  }
+  const mockAgent = new MockAgent();
+  setGlobalDispatcher(mockAgent);
+  undiciInterceptable = mockAgent.get(host);
 };
 
 export const mockCleanup = () => {
-  if (isNativeFetch) {
-    undiciInterceptable.close();
-  } else {
-    nock.cleanAll();
-  }
+  undiciInterceptable.close();
 };

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,4 +1,5 @@
 import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import * as qs from 'qs';
 import * as backlogjs from '../src/index';
 import * as Fixtures from './fixtures/index';
 import { mockRequest, mockPrepare, mockCleanup } from './mock';
@@ -37,18 +38,13 @@ describe('OAuth2 API', () => {
     mockRequest({
       method: 'POST',
       path: '/api/v2/oauth2/token',
-      body: (body) => {
-        return (
-          JSON.stringify(body) ===
-          JSON.stringify({
-            grant_type: 'authorization_code',
-            code: code,
-            client_id: clientId,
-            client_secret: clientSecret,
-            redirect_uri: redirectUri,
-          })
-        );
-      },
+      body: qs.stringify({
+        grant_type: 'authorization_code',
+        code: code,
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: redirectUri,
+      }),
       status: 200,
       data: Fixtures.access_token,
       times: 1,
@@ -65,14 +61,12 @@ describe('OAuth2 API', () => {
     mockRequest({
       method: 'POST',
       path: '/api/v2/oauth2/token',
-      body: (body) =>
-        JSON.stringify(body) ===
-        JSON.stringify({
-          grant_type: 'refresh_token',
-          client_id: clientId,
-          client_secret: clientSecret,
-          refresh_token: refreshToken,
-        }),
+      body: qs.stringify({
+        grant_type: 'refresh_token',
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+      }),
       status: 200,
       data: Fixtures.access_token,
       times: 1,


### PR DESCRIPTION
## Summary
- Remove `nock` dependency and replace mock implementation with Node.js built-in `undici` MockAgent
- Simplify `test/mock.ts` by leveraging `undici`'s native HTTP mocking capabilities

## Test plan
- [x] Verify all existing tests pass with the new mock implementation
- [x] Confirm `nock` is no longer in `package.json` or `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)