### PR TITLE
ci: drop Node 20 from test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Node 20 reached end-of-life on 2026-04-30. This removes it from the CI test matrix, keeping coverage on the active LTS / current lines (Node 22 and 24).

## Changes
- `.github/workflows/nodejs.yml`: test matrix `[20.x, 22.x, 24.x]` → `[22.x, 24.x]`

## Notes
- Unrelated to the `assert` test fix in #159.
- No `engines` field exists in `package.json`; left untouched to avoid imposing a new install-time constraint on consumers. Can be added in a follow-up if dropping Node 20 support should be declared explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)