### PR TITLE
ci: add type checking with tsc

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,6 +19,8 @@ jobs:
         cache: npm
     - name: Run npm ci
       run: npm ci
+    - name: Run typecheck
+      run: npm run typecheck
     - name: Run build
       run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "git://github.com/nulab/backlog-js.git"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/src/error.ts
+++ b/src/error.ts
@@ -2,7 +2,7 @@ export class BacklogError extends Error {
   private _name: BacklogErrorNameType;
   private _url: string;
   private _status: number;
-  private _body: { errors: BacklogErrorMessage[] };
+  private _body?: { errors: BacklogErrorMessage[] };
   private _response: Response;
   constructor(
     name: BacklogErrorNameType,
@@ -25,7 +25,7 @@ export class BacklogError extends Error {
   get status(): number {
     return this._status;
   }
-  get body(): { errors: BacklogErrorMessage[] } {
+  get body(): { errors: BacklogErrorMessage[] } | undefined {
     return this._body;
   }
   get response(): Response {

--- a/src/request.ts
+++ b/src/request.ts
@@ -41,12 +41,13 @@ export default class Request {
     const { method, path, params = <Params>{} } = options;
     const { apiKey, accessToken, timeout } = this.configure;
     const query: Params = apiKey ? { apiKey: apiKey } : {};
-    const init: RequestInit = { method: method, headers: {} };
+    const headers: Record<string, string> = {};
+    const init: RequestInit = { method: method, headers };
     if (timeout) {
       init['timeout'] = timeout;
     }
     if (!apiKey && accessToken) {
-      init.headers['Authorization'] = 'Bearer ' + accessToken;
+      headers['Authorization'] = 'Bearer ' + accessToken;
     }
     if (typeof window !== 'undefined') {
       init.mode = 'cors';
@@ -55,7 +56,7 @@ export default class Request {
       if (params instanceof FormData) {
         init.body = <FormData>params
       } else {
-        init.headers['Content-type'] = 'application/x-www-form-urlencoded';
+        headers['Content-type'] = 'application/x-www-form-urlencoded';
         init.body = this.toQueryString(params);
       }
     } else {


### PR DESCRIPTION
## 概要

TypeScript の型チェックを CI に組み込みます。`tsdown` のビルドはトランスパイルのみで型エラーでは落ちないため、これまで CI で型チェックが行われていませんでした。

## 変更内容

- `typecheck` スクリプト（`tsc --noEmit`）を追加
- CI の build ジョブに typecheck ステップを追加
- `src/error.ts`: `_body` / `body` getter を optional に修正
  - `UnexpectedError` は body を渡さず `super()` を呼ぶため `_body` は実際に `undefined` になるが、型は非optionalで不健全だった
- `src/request.ts`: headers を型付き `Record<string, string>` で組み立て、`'init.headers' is possibly 'undefined'` を解消

## 注意点（公開APIの型変更）

`BacklogError#body` getter の戻り値型が `{ errors } | undefined` に変わります（実態に即した正しい型ですが、利用側で undefined ハンドリングが必要になる可能性があります）。

## 確認

- `npm run typecheck` → pass
- `npm test` → 22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)