### PR TITLE
fix: type NodeFileData.body as ReadableStream instead of PassThrough

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,4 +1,4 @@
-import * as Types from './types';
+import * as Types from "./types";
 
 export namespace File {
   export type FileData = NodeFileData | BrowserFileData;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,11 +1,10 @@
-import { PassThrough } from "stream";
-import * as Types from "./types";
+import * as Types from './types';
 
 export namespace File {
   export type FileData = NodeFileData | BrowserFileData;
 
   export interface NodeFileData {
-    body: PassThrough;
+    body: ReadableStream;
     url: string;
     filename: string;
   }


### PR DESCRIPTION
## Summary

`Entity.File.NodeFileData.body` was typed as Node's `stream.PassThrough`, which required `import { PassThrough } from "stream"` in `entity.ts`. This was a leftover from when the client used `node-fetch`.

The client now uses `globalThis.fetch`, whose `response.body` is a **Web `ReadableStream`**, and `parseFileData` assigns it through an `any` cast — so the `PassThrough` annotation never matched the actual runtime value and was never type-checked.

## Changes

- `src/entity.ts`: type `NodeFileData.body` as `ReadableStream` (provided by the `dom` lib, no new dependency) and remove the `import { PassThrough } from "stream"`.

This also removes the only Node builtin (`stream`) import from the entity types, which was surfacing spurious "Cannot find name 'stream'" errors in some editor setups.

## Compatibility note

This changes a public type (`NodeFileData.body`: `PassThrough` → `ReadableStream`), so it is technically a type-level breaking change for TypeScript consumers that annotated against `PassThrough`. However, the runtime value was already a `ReadableStream`, so this is a correction of an inaccurate type rather than a behavioral change.

## Verification

- `npm run typecheck` — passes ✅
- `npm run lint` — clean ✅
- `npm test` — 29 tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
