### PR TITLE
feat: add configurable User-Agent support to API requests

### DIFF
--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -10,6 +10,7 @@ export default class Backlog extends Request {
     accessToken?: string;
     timeout?: number;
     fetch?: Fetch;
+    userAgent?: string;
   }) {
     super(configure);
   }

--- a/src/request.ts
+++ b/src/request.ts
@@ -12,6 +12,7 @@ export default class Request {
       accessToken?: string;
       timeout?: number;
       fetch?: Fetch;
+      userAgent?: string;
     },
   ) {
     this.fetch = configure.fetch ?? globalThis.fetch;
@@ -43,7 +44,7 @@ export default class Request {
     params?: Params | FormData;
   }): Promise<Response> {
     const { method, path, params = <Params>{} } = options;
-    const { apiKey, accessToken, timeout } = this.configure;
+    const { apiKey, accessToken, timeout, userAgent } = this.configure;
     const query: Params = apiKey ? { apiKey: apiKey } : {};
     const headers: Record<string, string> = {};
     const init: RequestInit = { method: method, headers };
@@ -52,6 +53,11 @@ export default class Request {
     }
     if (!apiKey && accessToken) {
       headers["Authorization"] = "Bearer " + accessToken;
+    }
+    // `User-Agent` is a forbidden header name in browsers and will be ignored there,
+    // so it is only applied when explicitly provided (e.g. from Node.js clients).
+    if (userAgent) {
+      headers["User-Agent"] = userAgent;
     }
     if (typeof window !== "undefined") {
       init.mode = "cors";

--- a/test/test.ts
+++ b/test/test.ts
@@ -473,6 +473,41 @@ describe("Custom fetch option", () => {
     expect(data).toEqual(Fixtures.space);
   });
 
+  it("should send the provided userAgent as the User-Agent header", async () => {
+    let capturedHeaders: HeadersInit | undefined;
+    const customFetch: typeof globalThis.fetch = (_input, init) => {
+      capturedHeaders = init?.headers;
+      return Promise.resolve(
+        new Response(JSON.stringify(Fixtures.space), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    const userAgent = "backlog-mcp-server/1.2.3";
+    const client = new backlogjs.Backlog({ host, apiKey, fetch: customFetch, userAgent });
+    await client.getSpace();
+    expect((capturedHeaders as Record<string, string>)["User-Agent"]).toBe(userAgent);
+  });
+
+  it("should not set a User-Agent header when userAgent is not provided", async () => {
+    let capturedHeaders: HeadersInit | undefined;
+    const customFetch: typeof globalThis.fetch = (_input, init) => {
+      capturedHeaders = init?.headers;
+      return Promise.resolve(
+        new Response(JSON.stringify(Fixtures.space), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    };
+
+    const client = new backlogjs.Backlog({ host, apiKey, fetch: customFetch });
+    await client.getSpace();
+    expect((capturedHeaders as Record<string, string>)["User-Agent"]).toBeUndefined();
+  });
+
   it("should use the provided fetch function in OAuth2.getAccessToken", async () => {
     let capturedUrl: string | undefined;
     const customFetch: typeof globalThis.fetch = (input, _init) => {


### PR DESCRIPTION
## Summary

Adds an optional `userAgent` option to the `Backlog` client. When provided, the value is sent as the `User-Agent` header on outgoing API requests. This lets downstream clients (e.g. [`backlog-mcp-server`](https://github.com/nulab/backlog-mcp-server)) identify their own traffic in Backlog API access logs / observability tooling (e.g. Datadog), so we can estimate how much traffic flows through a given client and track its adoption over time.

Closes #170

## Changes

- `src/request.ts`: accept `userAgent?` in the constructor config and set it as the `User-Agent` header **only when provided**.
- `src/backlog.ts`: expose `userAgent?` on the `Backlog` constructor config.
- `test/test.ts`: add tests covering both the provided and omitted cases.

## Usage

```ts
new Backlog({ host, apiKey, userAgent: `backlog-mcp-server/${version}` });
```

## Notes

- `User-Agent` is a forbidden header name in browsers and is silently ignored there, so it is applied only when explicitly set (Node.js clients such as the MCP Server can use it).
- Purely additive and backward compatible — when `userAgent` is omitted, no `User-Agent` header is added and behavior is unchanged.

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ (31 passed, incl. 2 new)
- `npm run lint` ✅
- `npm run fmt:check` ✅