### PR TITLE
docs: document ParentChildType semantics and add clearer aliases

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,5 +4,13 @@
   "categories": {
     "correctness": "error"
   },
-  "ignorePatterns": ["dist", "node_modules", "coverage"]
+  "ignorePatterns": ["dist", "node_modules", "coverage"],
+  "overrides": [
+    {
+      "files": ["src/option.ts"],
+      "rules": {
+        "no-duplicate-enum-values": "off"
+      }
+    }
+  ]
 }

--- a/src/option.ts
+++ b/src/option.ts
@@ -391,18 +391,67 @@ export namespace Issue {
     [customField_: string]: any;
   }
 
+  /**
+   * Filter for the `parentChild` search parameter of the issue list API.
+   *
+   * The hierarchy has up to three levels: top-level (1st) > child (2nd) > grandchild (3rd).
+   * Values 5-10 are only meaningful after the grandchild issue feature is released.
+   *
+   * @see https://developer.nulab.com/docs/backlog/api/2/get-issue-list/
+   */
   export enum ParentChildType {
+    /** All issues, regardless of hierarchy. */
     All = 0,
+
+    /** Issues that are not a child, i.e. issues with no parent (top-level or standalone). */
     NotChild = 1,
-    Child = 2,
+
+    /**
+     * Issues that have a parent, i.e. both 2nd-level (child) and 3rd-level (grandchild) issues.
+     *
+     * @deprecated The name `Child` is misleading because it also includes grandchildren.
+     * Use {@link ChildOrGrandchild} instead. `ChildOnly` (=6) matches 2nd-level issues only.
+     */
+    Child = 2, // oxlint-disable-line no-duplicate-enum-values -- intentional alias `ChildOrGrandchild`
+    /** Issues that have a parent, i.e. both 2nd-level (child) and 3rd-level (grandchild) issues. */
+    ChildOrGrandchild = 2,
+
+    /** Standalone issues with no hierarchy (neither a parent nor a child). */
     NotChildNotParent = 3,
-    Parent = 4,
-    GrandchildIssue = 5,
-    ChildIssue = 6,
-    ParentIssue = 7,
+
+    /**
+     * Issues that have children, i.e. any issue with at least one child.
+     * This is broader than {@link TopLevelOnly} (=7): it also includes a 2nd-level
+     * child that itself has grandchildren.
+     *
+     * @deprecated The name `Parent` is misleading; the official label is "has child issues"
+     * and it is not limited to top-level parents. Use {@link HasChildren} instead. For
+     * top-level parents only, use `TopLevelOnly` (=7).
+     */
+    Parent = 4, // oxlint-disable-line no-duplicate-enum-values -- intentional alias `HasChildren`
+    /**
+     * Issues that have children, i.e. any issue with at least one child.
+     * Broader than {@link TopLevelOnly} (=7): includes a 2nd-level child that has grandchildren.
+     */
+    HasChildren = 4,
+
+    /** 3rd-level issues only (grandchildren). */
+    GrandchildOnly = 5,
+
+    /** 2nd-level issues only (children, excluding grandchildren). */
+    ChildOnly = 6,
+
+    /** Top-level (1st-level) parent issues only. */
+    TopLevelOnly = 7,
+
+    /** Exclude 3rd-level issues (grandchildren). */
     ExcludeGrandchild = 8,
-    ExcludeGrandparent = 9,
-    LeafIssue = 10,
+
+    /** Exclude the top-level issue of a three-level hierarchy (the grandparent). */
+    ExcludeTopLevel = 9,
+
+    /** Leaf issues (the lowest level of their branch: a childless child or a grandchild). */
+    LeafOnly = 10,
   }
 
   export type IssueExpand = "childIssueSummary";

--- a/src/option.ts
+++ b/src/option.ts
@@ -391,66 +391,21 @@ export namespace Issue {
     [customField_: string]: any;
   }
 
-  /**
-   * Filter for the `parentChild` search parameter of the issue list API.
-   *
-   * The hierarchy has up to three levels: top-level (1st) > child (2nd) > grandchild (3rd).
-   * Values 5-10 are only meaningful after the grandchild issue feature is released.
-   *
-   * @see https://developer.nulab.com/docs/backlog/api/2/get-issue-list/
-   */
   export enum ParentChildType {
-    /** All issues, regardless of hierarchy. */
     All = 0,
-
-    /** Issues that are not a child, i.e. issues with no parent (top-level or standalone). */
     NotChild = 1,
-
-    /**
-     * Issues that have a parent, i.e. both 2nd-level (child) and 3rd-level (grandchild) issues.
-     *
-     * @deprecated The name `Child` is misleading because it also includes grandchildren.
-     * Use {@link ChildOrGrandchild} instead. `ChildOnly` (=6) matches 2nd-level issues only.
-     */
+    /** @deprecated Use {@link ChildOrGrandchild}. */
     Child = 2,
-    /** Issues that have a parent, i.e. both 2nd-level (child) and 3rd-level (grandchild) issues. */
     ChildOrGrandchild = 2,
-
-    /** Standalone issues with no hierarchy (neither a parent nor a child). */
     NotChildNotParent = 3,
-
-    /**
-     * Issues that have children, i.e. any issue with at least one child.
-     * This is broader than {@link TopLevelOnly} (=7): it also includes a 2nd-level
-     * child that itself has grandchildren.
-     *
-     * @deprecated The name `Parent` is misleading; the official label is "has child issues"
-     * and it is not limited to top-level parents. Use {@link HasChildren} instead. For
-     * top-level parents only, use `TopLevelOnly` (=7).
-     */
+    /** @deprecated Use {@link HasChildren}. */
     Parent = 4,
-    /**
-     * Issues that have children, i.e. any issue with at least one child.
-     * Broader than {@link TopLevelOnly} (=7): includes a 2nd-level child that has grandchildren.
-     */
     HasChildren = 4,
-
-    /** 3rd-level issues only (grandchildren). */
     GrandchildOnly = 5,
-
-    /** 2nd-level issues only (children, excluding grandchildren). */
     ChildOnly = 6,
-
-    /** Top-level (1st-level) parent issues only. */
     TopLevelOnly = 7,
-
-    /** Exclude 3rd-level issues (grandchildren). */
     ExcludeGrandchild = 8,
-
-    /** Exclude the top-level issue of a three-level hierarchy (the grandparent). */
     ExcludeTopLevel = 9,
-
-    /** Leaf issues (the lowest level of their branch: a childless child or a grandchild). */
     LeafOnly = 10,
   }
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -412,7 +412,7 @@ export namespace Issue {
      * @deprecated The name `Child` is misleading because it also includes grandchildren.
      * Use {@link ChildOrGrandchild} instead. `ChildOnly` (=6) matches 2nd-level issues only.
      */
-    Child = 2, // oxlint-disable-line no-duplicate-enum-values -- intentional alias `ChildOrGrandchild`
+    Child = 2,
     /** Issues that have a parent, i.e. both 2nd-level (child) and 3rd-level (grandchild) issues. */
     ChildOrGrandchild = 2,
 
@@ -428,7 +428,7 @@ export namespace Issue {
      * and it is not limited to top-level parents. Use {@link HasChildren} instead. For
      * top-level parents only, use `TopLevelOnly` (=7).
      */
-    Parent = 4, // oxlint-disable-line no-duplicate-enum-values -- intentional alias `HasChildren`
+    Parent = 4,
     /**
      * Issues that have children, i.e. any issue with at least one child.
      * Broader than {@link TopLevelOnly} (=7): includes a 2nd-level child that has grandchildren.

--- a/test/test.ts
+++ b/test/test.ts
@@ -245,7 +245,7 @@ describe("Backlog API", () => {
   it("should get issues with childIssueSummary expand and grandchild parentChild type.", async () => {
     const query = {
       apiKey,
-      parentChild: backlogjs.Option.Issue.ParentChildType.GrandchildIssue,
+      parentChild: backlogjs.Option.Issue.ParentChildType.GrandchildOnly,
       expand: ["childIssueSummary"],
     };
     const issue = {
@@ -265,7 +265,7 @@ describe("Backlog API", () => {
       times: 1,
     });
     const data = await backlog.getIssues({
-      parentChild: backlogjs.Option.Issue.ParentChildType.GrandchildIssue,
+      parentChild: backlogjs.Option.Issue.ParentChildType.GrandchildOnly,
       expand: ["childIssueSummary"],
     });
     expect(data).toEqual([issue]);
@@ -298,7 +298,7 @@ describe("Backlog API", () => {
 
   it("should serialize the expand parameter using bracket array format.", () => {
     const query = (backlog as any).toQueryString({
-      parentChild: backlogjs.Option.Issue.ParentChildType.GrandchildIssue,
+      parentChild: backlogjs.Option.Issue.ParentChildType.GrandchildOnly,
       expand: ["childIssueSummary"],
     });
     expect(query).toBe("parentChild=5&expand%5B%5D=childIssueSummary");
@@ -544,5 +544,25 @@ describe("Custom fetch option", () => {
     expect(capturedUrl).not.toBeUndefined();
     expect(capturedUrl!.includes("/api/v2/oauth2/token")).toBe(true);
     expect(data).toEqual(Fixtures.access_token);
+  });
+});
+
+describe("ParentChildType", () => {
+  const { ParentChildType } = backlogjs.Option.Issue;
+
+  it("keeps the deprecated aliases pointing at the same values", () => {
+    expect(ParentChildType.ChildOrGrandchild).toBe(ParentChildType.Child);
+    expect(ParentChildType.ChildOrGrandchild).toBe(2);
+    expect(ParentChildType.HasChildren).toBe(ParentChildType.Parent);
+    expect(ParentChildType.HasChildren).toBe(4);
+  });
+
+  it("maps the grandchild-related values to the documented numbers", () => {
+    expect(ParentChildType.GrandchildOnly).toBe(5);
+    expect(ParentChildType.ChildOnly).toBe(6);
+    expect(ParentChildType.TopLevelOnly).toBe(7);
+    expect(ParentChildType.ExcludeGrandchild).toBe(8);
+    expect(ParentChildType.ExcludeTopLevel).toBe(9);
+    expect(ParentChildType.LeafOnly).toBe(10);
   });
 });


### PR DESCRIPTION
## Summary

The `parentChild` search values are now finalized in the public API documentation ([get-issue-list](https://developer.nulab.com/docs/backlog/api/2/get-issue-list/) and the [API parameter update blog](https://backlog.com/ja/blog/backlog-update-api-parameter/)), so this reduces the naming cognitive load flagged in #158's review.

Closes #165

## Changes

- **Deprecate the misleading published names and add clearer aliases** (additive, non-breaking):
  - `Child` (2) → `@deprecated`, alias `ChildOrGrandchild` (2)
  - `Parent` (4) → `@deprecated`, alias `HasChildren` (4)
- **Rename the not-yet-released grandchild values (5–10)** to clearer names, since they have never shipped in a release:
  | value | before (#158) | after |
  |------:|---------------|-------|
  | 5 | `GrandchildIssue` | `GrandchildOnly` |
  | 6 | `ChildIssue` | `ChildOnly` |
  | 7 | `ParentIssue` | `TopLevelOnly` |
  | 8 | `ExcludeGrandchild` | `ExcludeGrandchild` (unchanged) |
  | 9 | `ExcludeGrandparent` | `ExcludeTopLevel` |
  | 10 | `LeafIssue` | `LeafOnly` |

## Compatibility

- Published names `All`/`NotChild`/`Child`/`NotChildNotParent`/`Parent` (0.16.0) all keep working; `Child`/`Parent` are only marked `@deprecated`.
- Values 5–10 were introduced in #158 and have **not** been released yet, so renaming them is safe.
- The intentional duplicate enum values (aliases) are allowed via a scoped `overrides` entry in `.oxlintrc.json` (`no-duplicate-enum-values` off for `src/option.ts` only).

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ (33 passed, incl. new `ParentChildType` alias/value tests)
- `npm run lint` ✅
- `npm run fmt:check` ✅
- `npm run build` ✅

## Semantics reference (verified against public docs)

| value | canonical name | meaning (official) |
|------:|----------------|--------------------|
| 0 | `All` | All |
| 1 | `NotChild` | Not a child (no parent) |
| 2 | `ChildOrGrandchild` | 2nd or 3rd level (child/grandchild) |
| 3 | `NotChildNotParent` | No hierarchy (standalone) |
| 4 | `HasChildren` | Has child issues |
| 5 | `GrandchildOnly` | 3rd level (grandchild) |
| 6 | `ChildOnly` | 2nd level (child) |
| 7 | `TopLevelOnly` | Top level |
| 8 | `ExcludeGrandchild` | Exclude 3rd level |
| 9 | `ExcludeTopLevel` | Exclude top level (of a 3-level tree) |
| 10 | `LeafOnly` | Leaf level |