### PR TITLE
fix(ci): pass NODE_AUTH_TOKEN to npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,8 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Push version update
         env:


### PR DESCRIPTION
## Problem

The release workflow failed at publish with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/backlog-js - Not found
```

Despite the "Not found" wording, `backlog-js` already exists on npm (0.16.0). A 404 on `PUT` to an existing package is npm's response to an **unauthenticated / unauthorized** publish (it masks this as 404 to avoid leaking package existence). Provenance signing (OIDC) runs *before* the registry PUT, which is why the log shows provenance succeeding while only the final PUT fails.

## Root cause

The publish step sets up the registry via `setup-node`'s `registry-url`, which writes an `.npmrc` referencing `${NODE_AUTH_TOKEN}` — but the `npm publish` step never provides that env var, so npm publishes unauthenticated.

## Fix

```yaml
- name: Publish to npm
  run: npm publish --provenance --access public
  env:
    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

## ⚠️ Required before this works

An `NPM_TOKEN` secret must exist and be reachable by the `publish` job (which runs in the `production` environment — the secret should be set at the repo level or on that environment):

- Type: **Automation** or **Granular access** token (these bypass 2FA, which is required for CI publishing).
- Scope: **read and write** access to the `backlog-js` package, owned by an account/team with publish rights.

If a token secret with a different name already exists, adjust `secrets.NPM_TOKEN` accordingly.

> Note: alternatively, npm **Trusted Publishing** (tokenless OIDC) could be used instead — but that requires configuring the trusted publisher on npmjs.org and upgrading the npm CLI to ≥ 11.5.1 (Node 22 ships an older npm). The token approach matches the workflow's existing setup, so this PR takes that route.