### PR TITLE
fix(ci): use npm new enough for Trusted Publishing

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         cache: npm
     - name: Run npm ci
       run: npm ci
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [24.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -97,10 +97,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
+          node-version: 24
 
       - name: Download build artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Problem

The release workflow failed at publish:

```
npm notice publish Signed provenance statement ... from GitHub Actions
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/backlog-js - Not found
```

OIDC provenance signing succeeded, but the registry `PUT` was **unauthenticated** (npm returns 404 for that). The workflow is set up for **Trusted Publishing** (tokenless OIDC — `id-token: write` + `--provenance`), but the publish never authenticated.

## Root cause

Node 22 bundles **npm 10.x**, which is too old to authenticate via npm Trusted Publishing. Tokenless OIDC publishing requires **npm >= 11.5.1**. With an old npm, publish falls back to token auth, finds no token, and gets a 404.

## Fix

- Bump the publish job to **Node 24**, whose bundled npm satisfies the requirement. This mirrors `backlog-mcp-server`, which also relies on the `setup-node` toolchain rather than pinning `npm@latest` (avoiding a non-reproducible "always latest" upgrade).
- Remove `registry-url` from `setup-node` in the publish job — it wrote a token-based `.npmrc` (`_authToken=${NODE_AUTH_TOKEN}`) that is unnecessary and can interfere with OIDC. No `NODE_AUTH_TOKEN` / `NPM_TOKEN` secret is needed.
- Bump `actions/setup-node` to `v6` (matches `nodejs.yml`).

## Requirement (npmjs.org side)

Trusted Publishing also needs the **Trusted Publisher configured on npmjs.org** for `backlog-js`:
- Publisher: GitHub Actions
- Repository: `nulab/backlog-js`
- Workflow: `release.yml`
- Environment: `production`

If that is already configured, this workflow change alone should make the release succeed.

## Note

Supersedes #173 (which took the token-based approach). This keeps releases tokenless, so no long-lived npm token needs to be stored as a secret.