### PR TITLE
fix: validate userAgent to prevent header injection

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -3,7 +3,9 @@ import * as qs from "qs";
 import type { Fetch } from "./types";
 
 // Matches ASCII control characters (C0 range 0x00-0x1F and DEL 0x7F),
-// including CR (0x0D) and LF (0x0A).
+// including CR (0x0D) and LF (0x0A). Matching control characters is the intent
+// here (rejecting them), so the lint rule is disabled for this line.
+// eslint-disable-next-line no-control-regex
 const CONTROL_CHARACTER = /[\x00-\x1f\x7f]/;
 
 export default class Request {

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,7 +4,6 @@ import type { Fetch } from "./types";
 
 // Matches ASCII control characters (C0 range 0x00-0x1F and DEL 0x7F),
 // including CR (0x0D) and LF (0x0A).
-// eslint-disable-next-line no-control-regex
 const CONTROL_CHARACTER = /[\x00-\x1f\x7f]/;
 
 export default class Request {

--- a/src/request.ts
+++ b/src/request.ts
@@ -2,6 +2,11 @@ import * as Error from "./error";
 import * as qs from "qs";
 import type { Fetch } from "./types";
 
+// Matches ASCII control characters (C0 range 0x00-0x1F and DEL 0x7F),
+// including CR (0x0D) and LF (0x0A).
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTER = /[\x00-\x1f\x7f]/;
+
 export default class Request {
   private readonly fetch: Fetch;
 
@@ -16,6 +21,13 @@ export default class Request {
     },
   ) {
     this.fetch = configure.fetch ?? globalThis.fetch;
+    // Reject control characters (including CR/LF) in userAgent to prevent header
+    // injection: a value containing "\r\n" could otherwise smuggle extra headers.
+    if (configure.userAgent !== undefined && CONTROL_CHARACTER.test(configure.userAgent)) {
+      throw new globalThis.Error(
+        "Invalid userAgent: control characters (including CR/LF) are not allowed.",
+      );
+    }
   }
 
   public get<T>(path: string, params?: any): Promise<T> {

--- a/test/test.ts
+++ b/test/test.ts
@@ -508,6 +508,21 @@ describe("Custom fetch option", () => {
     expect((capturedHeaders as Record<string, string>)["User-Agent"]).toBeUndefined();
   });
 
+  it("should reject a userAgent containing control characters (CR/LF)", () => {
+    expect(
+      () => new backlogjs.Backlog({ host, apiKey, userAgent: "evil\r\nX-Injected: 1" }),
+    ).toThrow(/Invalid userAgent/);
+    expect(() => new backlogjs.Backlog({ host, apiKey, userAgent: "bad\x00nul" })).toThrow(
+      /Invalid userAgent/,
+    );
+  });
+
+  it("should accept a normal userAgent", () => {
+    expect(
+      () => new backlogjs.Backlog({ host, apiKey, userAgent: "backlog-mcp-server/1.2.3" }),
+    ).not.toThrow();
+  });
+
   it("should use the provided fetch function in OAuth2.getAccessToken", async () => {
     let capturedUrl: string | undefined;
     const customFetch: typeof globalThis.fetch = (input, _init) => {


### PR DESCRIPTION
## Background

Follow-up to the `userAgent` option added in #171 (released in v0.17.0). As raised in review, letting an arbitrary `userAgent` fully overwrite the `User-Agent` header is a security concern: injecting control characters into a header value to smuggle/spoof additional headers is a classic **HTTP header injection** technique. If a caller forwards untrusted input as `userAgent`, a value like `"foo\r\nX-Injected: 1"` could split into extra headers.

## Change

Validate `userAgent` at construction time and throw if it contains any ASCII control character (`0x00`–`0x1F`, including CR/LF, or `0x7F`):

```ts
const CONTROL_CHARACTER = /[\x00-\x1f\x7f]/;
// ...
if (configure.userAgent !== undefined && CONTROL_CHARACTER.test(configure.userAgent)) {
  throw new globalThis.Error(
    "Invalid userAgent: control characters (including CR/LF) are not allowed.",
  );
}
```

- Fails fast in the constructor (once), rather than per request.
- Normal User-Agent strings (e.g. `backlog-mcp-server/1.2.3`) are unaffected — backward compatible.

## Tests

- Rejects `userAgent` containing `\r\n` and `\x00`.
- Accepts a normal `userAgent`.

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ (35 passed, incl. 2 new)
- `npm run lint` ✅
- `npm run fmt:check` ✅
- `npm run build` ✅

## Note

This addresses the "completely overwriting the UA is not recommended" review comment on the security-critical axis (control-character injection). Appending to a library-default base UA instead of full overwrite is a separate behavior change and is intentionally not included here; happy to follow up if desired.