### PR TITLE
feat: add Standalone alias for NotChildNotParent (value 3)

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -397,7 +397,9 @@ export namespace Issue {
     /** @deprecated Use {@link ChildOrGrandchild}. */
     Child = 2,
     ChildOrGrandchild = 2,
+    /** @deprecated Use {@link Standalone}. */
     NotChildNotParent = 3,
+    Standalone = 3,
     /** @deprecated Use {@link HasChildren}. */
     Parent = 4,
     HasChildren = 4,

--- a/test/test.ts
+++ b/test/test.ts
@@ -555,6 +555,8 @@ describe("ParentChildType", () => {
     expect(ParentChildType.ChildOrGrandchild).toBe(2);
     expect(ParentChildType.HasChildren).toBe(ParentChildType.Parent);
     expect(ParentChildType.HasChildren).toBe(4);
+    expect(ParentChildType.Standalone).toBe(ParentChildType.NotChildNotParent);
+    expect(ParentChildType.Standalone).toBe(3);
   });
 
   it("maps the grandchild-related values to the documented numbers", () => {


### PR DESCRIPTION
## Summary

Adds a clearer `Standalone` alias for `ParentChildType` value `3` and deprecates `NotChildNotParent`.

Value `3` selects issues that have **neither a parent nor a child** — i.e. standalone issues — but the published name `NotChildNotParent` is verbose and hard to parse. This adds a friendlier `Standalone` alias while keeping the existing name working.

This follows the exact same additive, non-breaking pattern already established in #172 for `Child`/`ChildOrGrandchild` and `Parent`/`HasChildren`.

## Changes

- `src/option.ts`: add `Standalone = 3` alias, mark `NotChildNotParent` `@deprecated` (points to `Standalone`).
- `test/test.ts`: assert `Standalone === NotChildNotParent === 3`.

## Compatibility

- Non-breaking: `NotChildNotParent` keeps working and only gains a deprecation hint.
- The official API documentation name stays `NotChildNotParent`; `Standalone` is a client-side convenience alias (documented via the doc comment).

## Related

- Mirrors the same change in backlog4j: nulab/backlog4j#102
- Naming discussion originated in the backlog4j grandchild review.

## Verification

- `npm run typecheck` ✅
- `npx vitest run -t "ParentChildType"` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)