### PR TITLE
fix: encode parameter values in the authorization url

### DIFF
--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -24,7 +24,7 @@ export default class OAuth2 {
     return (
       `https://${options.host}/OAuth2AccessRequest.action?` +
       Object.keys(params)
-        .map((key) => (params[key] ? `${key}=${params[key]}` : ""))
+        .map((key) => (params[key] ? `${key}=${encodeURIComponent(params[key])}` : ""))
         .filter((x) => x.length > 0)
         .join("&")
     );

--- a/test/test.ts
+++ b/test/test.ts
@@ -32,6 +32,16 @@ describe("OAuth2 API", () => {
     expect(oauth2.getAuthorizationURL({ host, redirectUri, state })).toBe(expected);
   });
 
+  it("should encode parameter values in the authorization url.", () => {
+    const redirectUri = "https://app.example.com/callback?tenant=acme&lang=ja";
+    const state = "ab+cd/ef==";
+    const params = new URL(oauth2.getAuthorizationURL({ host, redirectUri, state })).searchParams;
+
+    expect(params.get("redirect_uri")).toBe(redirectUri);
+    expect(params.get("state")).toBe(state);
+    expect([...params.keys()]).toEqual(["client_id", "response_type", "redirect_uri", "state"]);
+  });
+
   it("should get access token.", async () => {
     mockRequest({
       method: "POST",


### PR DESCRIPTION
`OAuth2.getAuthorizationURL` builds the query string by interpolating the values directly, so `redirect_uri` and `state` are sent unencoded:

```ts
.map((key) => (params[key] ? `${key}=${params[key]}` : ""))
```

Two ways this breaks, both reproduced against `master`:

**1. A base64 `state` loses its `+`.** `crypto.randomBytes(n).toString("base64")` is a common way to generate one:

```
state passed in : ab+cd/ef==
state the server receives : ab cd/ef==
```

`+` in a query string means space, so the value that comes back on the callback no longer matches what was sent and the CSRF check fails — intermittently, since it only happens when the random bytes encode to a `+`.

**2. A `redirect_uri` that has its own query string is truncated.**

```
redirectUri passed in : https://app.example.com/callback?tenant=acme&lang=ja
redirect_uri the server receives : https://app.example.com/callback?tenant=acme
authorization request params : client_id, response_type, redirect_uri, lang, state
```

The `&lang=ja` is parsed as a parameter of the authorization request itself, and the truncated `redirect_uri` no longer matches the registered one.

Applying `encodeURIComponent` to the values fixes both. Existing behaviour is unchanged for values without reserved characters, so the current test still passes as-is.

Verified on Node 24 (the version used in CI):

- added a regression test that round-trips `redirect_uri` and `state` through `URL.searchParams` and asserts no extra parameters leak in — it fails before this change and passes after
- `npm test` — 36 tests pass
- `npm run lint`, `npm run fmt:check`, `npm run typecheck`, `npm run build` — all clean