### PR TITLE
chore: add .npmrc with min-release-age to mitigate npm supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
Closes #152

### Summary

- Added a `.npmrc` file with `min-release-age=3`.
- This tells npm to only install package versions that were published at least 3 days ago.
- It reduces the risk of a supply chain attack, since malicious versions are often published and used within hours of release, before they get caught.