### PR TITLE
feat: add externalFileLinks to Issue entity

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -620,8 +620,20 @@ export namespace Issue {
     customFields: CustomFieldValue.CustomFieldValue[];
     attachments: File.IssueFileInfo[];
     sharedFiles: Project.SharedFile[];
+    externalFileLinks: ExternalFileLink[];
     stars: Star.Star[];
     childIssueSummary?: ChildIssueSummary;
+  }
+
+  export interface ExternalFileLink {
+    id: number;
+    serviceType: string;
+    name: string;
+    url: string;
+    createdUser?: User.User;
+    created: string;
+    updatedUser?: User.User;
+    updated: string;
   }
 
   export interface ChildIssueSummary {

--- a/test/test.ts
+++ b/test/test.ts
@@ -306,6 +306,41 @@ describe("Backlog API", () => {
     expect(data.childIssueSummary).toEqual({ total: 3, closed: 1 });
   });
 
+  it("should get a single issue with externalFileLinks.", async () => {
+    const externalFileLink = {
+      id: 10,
+      serviceType: "googledrive",
+      name: "spec.pdf",
+      url: "https://drive.google.com/file/d/xxxx/view",
+      createdUser: null,
+      created: "2026-07-28T00:00:00Z",
+      updatedUser: null,
+      updated: "2026-07-28T00:00:00Z",
+    };
+    const issue = {
+      id: 1,
+      projectId: 1,
+      issueKey: "TEST-1",
+      keyId: 1,
+      summary: "with external file link",
+      sharedFiles: [],
+      externalFileLinks: [externalFileLink],
+    };
+    mockRequest({
+      method: "GET",
+      path: "/api/v2/issues/TEST-1",
+      query: { apiKey },
+      status: 200,
+      data: issue,
+      times: 1,
+    });
+    const data = await backlog.getIssue("TEST-1");
+    expect(data).toEqual(issue);
+    expect(data.externalFileLinks).toHaveLength(1);
+    expect(data.externalFileLinks[0].serviceType).toBe("googledrive");
+    expect(data.externalFileLinks[0].url).toBe(externalFileLink.url);
+  });
+
   it("should serialize the expand parameter using bracket array format.", () => {
     const query = (backlog as any).toQueryString({
       parentChild: backlogjs.Option.Issue.ParentChildType.GrandchildOnly,


### PR DESCRIPTION
## Summary

`GET /api/v2/issues/:issueIdOrKey` のレスポンスには `externalFileLinks`（サーバ側 `IssueJson.sharedExternalFileLinks`）が含まれていますが、`Entity.Issue.Issue` にこのフィールドが無く、利用側でキャストが必要でした。型を追加します。

## Changes

- `Entity.Issue.Issue` に `externalFileLinks: ExternalFileLink[]` を追加
- `Entity.Issue.ExternalFileLink` を追加（`id` / `serviceType` / `name` / `url` / `createdUser` / `created` / `updatedUser` / `updated`）
  - `createdUser` / `updatedUser` はサーバ側が `Option[User]` のため optional
- Get Issue のレスポンスに `externalFileLinks` が含まれることを確認するテストを追加

## Verification

実際の Backlog スペースに対して `GET /api/v2/issues/:issueIdOrKey` を叩き、リンクが無い課題でも `externalFileLinks: []` が常に返ることを確認しました。

`npm run typecheck` / `npm test` / `npm run lint` / `npm run fmt:check` いずれもパスしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)