### PR TITLE
feat: support the related issues API

### DIFF
--- a/src/backlog.ts
+++ b/src/backlog.ts
@@ -811,6 +811,39 @@ export default class Backlog extends Request {
   }
 
   /**
+   * Get the list of issues related to the specified issue.
+   *
+   * GET /api/v2/issues/:issueIdOrKey/relatedIssues
+   */
+  public getRelatedIssues(issueIdOrKey: string | number): Promise<Entity.Issue.RelatedIssue[]> {
+    return this.get(`issues/${issueIdOrKey}/relatedIssues`);
+  }
+
+  /**
+   * Add a related issue to the specified issue.
+   *
+   * POST /api/v2/issues/:issueIdOrKey/relatedIssues
+   */
+  public addRelatedIssue(
+    issueIdOrKey: string | number,
+    params: Option.Issue.AddRelatedIssueParams,
+  ): Promise<Entity.Issue.RelatedIssue> {
+    return this.post(`issues/${issueIdOrKey}/relatedIssues`, params);
+  }
+
+  /**
+   * Remove a related issue from the specified issue.
+   *
+   * DELETE /api/v2/issues/:issueIdOrKey/relatedIssues/:relatedIssueId
+   */
+  public removeRelatedIssue(
+    issueIdOrKey: string | number,
+    relatedIssueId: number,
+  ): Promise<Entity.Issue.RelatedIssue> {
+    return this.delete(`issues/${issueIdOrKey}/relatedIssues/${relatedIssueId}`);
+  }
+
+  /**
    * https://developer.nulab.com/docs/backlog/api/2/get-wiki-page-list/
    */
   public getWikis(params: Option.Wiki.GetWikiParams): Promise<Entity.Wiki.WikiListItem[]> {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -624,6 +624,10 @@ export namespace Issue {
     childIssueSummary?: ChildIssueSummary;
   }
 
+  export interface RelatedIssue extends Issue {
+    type: Types.IssueRelationType;
+  }
+
   export interface ChildIssueSummary {
     total: number;
     closed: number;

--- a/src/option.ts
+++ b/src/option.ts
@@ -462,6 +462,10 @@ export namespace Issue {
   export interface LinkIssueSharedFilesParams {
     fileId: number[];
   }
+
+  export interface AddRelatedIssueParams {
+    targetIssueId: number;
+  }
 }
 
 export namespace PullRequest {

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,9 @@ export enum CustomFieldType {
   Radio = 8,
 }
 
+/** Relation type of a related issue. `PRECEDES` is reserved for future use. */
+export type IssueRelationType = "RELATES" | "PRECEDES";
+
 export type WebhookActivityId = number;
 
 export type Fetch = typeof globalThis.fetch;

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,8 +99,8 @@ export enum CustomFieldType {
   Radio = 8,
 }
 
-/** Relation type of a related issue. `PRECEDES` is reserved for future use. */
-export type IssueRelationType = "RELATES" | "PRECEDES";
+/** Relation type of a related issue. Only the undirected `RELATES` link is available. */
+export type IssueRelationType = "RELATES";
 
 export type WebhookActivityId = number;
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -306,6 +306,81 @@ describe("Backlog API", () => {
     expect(data.childIssueSummary).toEqual({ total: 3, closed: 1 });
   });
 
+  it("should get related issues.", async () => {
+    const relatedIssues = [
+      {
+        id: 2,
+        projectId: 1,
+        issueKey: "TEST-2",
+        keyId: 2,
+        summary: "related",
+        type: "RELATES",
+      },
+      {
+        id: 3,
+        projectId: 1,
+        issueKey: "TEST-3",
+        keyId: 3,
+        summary: "related too",
+        type: "RELATES",
+      },
+    ];
+    mockRequest({
+      method: "GET",
+      path: "/api/v2/issues/TEST-1/relatedIssues",
+      query: { apiKey },
+      status: 200,
+      data: relatedIssues,
+      times: 1,
+    });
+    const data = await backlog.getRelatedIssues("TEST-1");
+    expect(data).toEqual(relatedIssues);
+    expect(data[0].type).toBe("RELATES");
+  });
+
+  it("should add a related issue.", async () => {
+    const relatedIssue = {
+      id: 2,
+      projectId: 1,
+      issueKey: "TEST-2",
+      keyId: 2,
+      summary: "related",
+      type: "RELATES",
+    };
+    mockRequest({
+      method: "POST",
+      path: "/api/v2/issues/TEST-1/relatedIssues",
+      query: { apiKey },
+      body: qs.stringify({ targetIssueId: 2 }),
+      status: 200,
+      data: relatedIssue,
+      times: 1,
+    });
+    const data = await backlog.addRelatedIssue("TEST-1", { targetIssueId: 2 });
+    expect(data).toEqual(relatedIssue);
+  });
+
+  it("should remove a related issue.", async () => {
+    const relatedIssue = {
+      id: 2,
+      projectId: 1,
+      issueKey: "TEST-2",
+      keyId: 2,
+      summary: "related",
+      type: "RELATES",
+    };
+    mockRequest({
+      method: "DELETE",
+      path: "/api/v2/issues/TEST-1/relatedIssues/2",
+      query: { apiKey },
+      status: 200,
+      data: relatedIssue,
+      times: 1,
+    });
+    const data = await backlog.removeRelatedIssue("TEST-1", 2);
+    expect(data).toEqual(relatedIssue);
+  });
+
   it("should serialize the expand parameter using bracket array format.", () => {
     const query = (backlog as any).toQueryString({
       parentChild: backlogjs.Option.Issue.ParentChildType.GrandchildOnly,


### PR DESCRIPTION
## Summary

Adds client support for the issue relation ("related issues") endpoints:

| Method | Endpoint |
| --- | --- |
| `getRelatedIssues(issueIdOrKey)` | `GET /api/v2/issues/:issueIdOrKey/relatedIssues` |
| `addRelatedIssue(issueIdOrKey, params)` | `POST /api/v2/issues/:issueIdOrKey/relatedIssues` |
| `removeRelatedIssue(issueIdOrKey, relatedIssueId)` | `DELETE /api/v2/issues/:issueIdOrKey/relatedIssues/:relatedIssueId` |

## Types

- `Entity.Issue.RelatedIssue extends Entity.Issue.Issue` — the responses are plain Issue objects with an extra `type` field carrying the relation type, so extending `Issue` mirrors the wire format exactly.
- `Types.IssueRelationType = "RELATES"` — kept to what the API actually supports today. The server also defines a reserved relation type that is neither accepted nor returned yet; exposing it here would leak an unreleased feature into the client surface, so it is intentionally left out and can be added when it ships.
- `Option.Issue.AddRelatedIssueParams = { targetIssueId: number }`.

## Usage

```ts
const related = await backlog.getRelatedIssues("SAMPLE-1");
//    ^? Entity.Issue.RelatedIssue[]   e.g. [{ id: 2, issueKey: "SAMPLE-2", type: "RELATES", ... }]

await backlog.addRelatedIssue("SAMPLE-1", { targetIssueId: 2 });
await backlog.removeRelatedIssue("SAMPLE-1", 2);
```

## Verification

Unit tests were added for all three methods (the `POST` test also asserts the form-encoded request body).

The methods were additionally exercised against a real Backlog space, which confirmed:

- `addRelatedIssue` / `removeRelatedIssue` return the **target** issue plus `type: "RELATES"`.
- The relation is undirected — after adding it from the source issue, `getRelatedIssues` on the target issue returns the source issue.
- Adding the same relation twice is idempotent (the list stays at one entry).
- Removing a relation that does not exist rejects with `Error.BacklogApiError` (HTTP 404), so no special handling is needed on the client side.

`npm run typecheck`, `npm test`, `npm run lint` and `npm run fmt:check` all pass.

## Notes

The JSDoc comments reference the endpoint paths rather than developer.nulab.com URLs, because the documentation pages for these endpoints are not published yet. They should be swapped for the canonical URLs once the docs go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)