### PR TITLE
fix: type DocumentTree.projectId as number

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -498,7 +498,7 @@ export namespace Document {
   }
 
   export interface DocumentTree {
-    projectId: string;
+    projectId: number;
     activeTree?: ActiveTrashTree;
     trashTree?: ActiveTrashTree;
   }

--- a/test/fixtures/documentTree.ts
+++ b/test/fixtures/documentTree.ts
@@ -1,6 +1,30 @@
-export const documentTree = {
-  id: "01939983409c79d5a06a49859789e38f",
-  name: "Home",
-  documents: [],
-  children: [],
+import type { Entity } from "../../src/index";
+
+// Shaped after a real GET /api/v2/documents/tree response. The annotation is
+// what pins projectId to a number: without it nothing checks this fixture
+// against DocumentTree, which is how the wrong type went unnoticed.
+export const documentTree: Entity.Document.DocumentTree = {
+  projectId: 1073957945,
+  activeTree: {
+    id: "Active",
+    children: [
+      {
+        id: "0198e9b71087724f93c8651e12a0a539",
+        name: "Home",
+        emoji: "🏠",
+        children: [
+          {
+            id: "019da890d45b773ab9dd613f0017658f",
+            name: "Nested",
+            emoji: "",
+            children: [],
+          },
+        ],
+      },
+    ],
+  },
+  trashTree: {
+    id: "Trash",
+    children: [],
+  },
 };

--- a/test/test.ts
+++ b/test/test.ts
@@ -457,6 +457,8 @@ describe("Backlog API", () => {
     });
     const data = await backlog.getDocumentTree(projectIdOrKey);
     expect(data).toEqual(Fixtures.documentTree);
+    // The API returns projectId as a number, not a string.
+    expect(typeof data.projectId).toBe("number");
   });
 
   it("should get a document.", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
         "skipLibCheck": true
     },
     "include": [
-        "src/**/*"
+        "src/**/*",
+        "test/**/*"
     ],
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Fixes #183.

## Problem

`Entity.Document.DocumentTree.projectId` was declared as `string`, but the Backlog API returns a number.

```diff
  export interface DocumentTree {
-   projectId: string;
+   projectId: number;
    activeTree?: ActiveTrashTree;
    trashTree?: ActiveTrashTree;
  }
```

Three independent signals agree:

1. **A live response.** `GET /api/v2/projects/:projectIdOrKey/documents/tree` returns `"projectId": 1073957945` — an unquoted JSON number. The sibling tree node `id` fields genuinely are strings and were already declared correctly, so this is specific to `projectId`.
2. **It was the only outlier.** Of the 15 `projectId` declarations in `src/entity.ts`, 14 were `number` and this was the single `string`.
3. **It contradicted its own namespace.** `Document.projectId` is `number` twelve lines above `DocumentTree` in the same `export namespace Document`.

## Why the existing test did not catch it

`test/fixtures/documentTree.ts` did not resemble a document tree at all:

```ts
export const documentTree = {
  id: "01939983409c79d5a06a49859789e38f",
  name: "Home",
  documents: [],
  children: [],
};
```

No `projectId`, no `activeTree`/`trashTree`. And because the test asserted `expect(data).toEqual(Fixtures.documentTree)` — comparing the mocked response against the very fixture that produced it — it passed no matter what the declared types said. Nothing in the test suite referenced `DocumentTree`.

## Changes

- **`src/entity.ts`** — `projectId: string` → `number`.
- **`test/fixtures/documentTree.ts`** — rebuilt from a real response and annotated with `Entity.Document.DocumentTree`. The annotation is what actually pins the field type.
- **`tsconfig.json`** — `include` now covers `test/**/*`. The fixture annotation has no effect unless test files are typechecked; previously only `src/**/*` was included. This surfaces **no other errors** across the test directory.
- **`test/test.ts`** — added `expect(typeof data.projectId).toBe("number")` so the contract is enforced by vitest too, not only by `tsc`.

## Verification

- [x] `npm run typecheck` — pass (now covering `test/` as well)
- [x] `npm test` — 39 tests passing
- [x] `npm run lint` (oxlint) — clean
- [x] `npm run fmt:check` (oxfmt) — clean
- [x] `npm run build` — succeeds; emitted `dist/index.d.mts` contains `projectId: number`
- [x] **Guard confirmed:** restoring `projectId: string` fails typecheck with `test/fixtures/documentTree.ts(7,3): error TS2322: Type 'number' is not assignable to type 'string'.`

## Compatibility

Type-only change — the runtime value was always a number, so no behaviour changes. It is nonetheless **breaking at compile time** for anyone who wrote code against the incorrect `string` type, though such code could not have been correct at runtime (for example `projectId.startsWith(...)` would have thrown).

Worth calling out in release notes.

## Context

Found while migrating [`nulab/backlog-mcp-server`](https://github.com/nulab/backlog-mcp-server) to zod v4. Its output schema for `get_document_tree` declares `projectId` as `z.number()`, matching the real API, so `getDocumentTree()`'s return value stopped being assignable once the surrounding types tightened. That repo currently works around it with an `as unknown as` cast, which can be dropped after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
