### PR TITLE
add document, documentComment, and documentCommentReply properties to Notification

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -475,6 +475,35 @@ export namespace Document {
     created: string;
     updatedUser: User.User;
     updated: string;
+    childDocumentIds: string[];
+  }
+
+  export interface DocumentComment {
+    id: string;
+    documentId: string;
+    statusId: number;
+    content: string;
+    plain: string;
+    commentType: string;
+    createdUserId: number;
+    created: string;
+    updatedUserId: number;
+    updated: string;
+    createdUser: User.User;
+    replies: DocumentCommentReply[];
+  }
+
+  export interface DocumentCommentReply {
+    id: string;
+    documentId: string;
+    commentId: string;
+    content: string;
+    plain: string;
+    createdUserId: number;
+    created: string;
+    updatedUserId: number;
+    updated: string;
+    createdUser: User.User;
   }
 
   export interface Tag {
@@ -866,6 +895,9 @@ export namespace Notification {
     comment?: Issue.Comment;
     pullRequest?: PullRequest.PullRequest;
     pullRequestComment?: PullRequest.Comment;
+    document?: Document.Document;
+    documentComment?: Document.DocumentComment;
+    documentCommentReply?: Document.DocumentCommentReply;
     sender: User.User;
     created: string;
   }


### PR DESCRIPTION
## Summary

Adds the document-related payload fields the Backlog API returns on notifications, so `Notification.Notification` can carry document, document comment, and document comment reply context.

## Changes

**`src/entity.ts`**

- Added three optional properties to `Notification.Notification`, alongside the existing `issue` / `comment` / `pullRequest` / `pullRequestComment` fields:

  ```diff
    comment?: Issue.Comment;
    pullRequest?: PullRequest.PullRequest;
    pullRequestComment?: PullRequest.Comment;
  + document?: Document.Document;
  + documentComment?: Document.DocumentComment;
  + documentCommentReply?: Document.DocumentCommentReply;
  ```

  They are optional because a notification carries only the fields relevant to its `reason`.

- Added `Document.DocumentComment` and `Document.DocumentCommentReply` interfaces, which did not exist before — the two new notification fields above need them. `DocumentComment.replies` is typed as `DocumentCommentReply[]`.

- Added `childDocumentIds: string[]` to the existing `Document.Document` interface.

### Impact

Type-declaration only — no runtime code changes, and no changes to any request or response handling.

The two new interfaces are additive, so they can't break existing consumers. The three new `Notification` properties are optional, so existing code that constructs a `Notification` still compiles.

The one change that is **not** purely additive is `childDocumentIds: string[]` on `Document.Document` — it is required, not optional. Any consumer that constructs a `Document.Document` object literal (tests, mocks, fixtures) will now fail to compile until they add the field.

### Review notes

- **`childDocumentIds` is required and widens an existing interface.** Worth confirming the API always returns it on every endpoint that yields a `Document` — if it can be absent (e.g. on a leaf document, or on the document embedded in a notification payload), it should be `childDocumentIds?:` instead. This is the only breaking-change risk in the PR.
- **`id` fields are typed as `string`.** `DocumentComment.id` / `documentId` / `commentId` and their `DocumentCommentReply` equivalents follow `Document.Document.id`, which is already `string` (document IDs are hex strings, not numbers). Worth sanity-checking against a live response — #184 was exactly this class of bug in the other direction.
- **`statusId` / `commentType` on `DocumentComment`** are typed as `number` / `string`. If either has a fixed set of values, a union type may be more useful than the primitive.
- **No test coverage.** These are type-only declarations with no fixtures asserting the shape. As #184 showed, the existing fixture-vs-fixture assertions would not catch a wrong type here anyway — but flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
